### PR TITLE
edit account info now prepopulates form with user data

### DIFF
--- a/controllers/account-viewCtrl.js
+++ b/controllers/account-viewCtrl.js
@@ -8,7 +8,17 @@ module.exports.myAccountView = (req, res) => {
     let userData = foundUser.dataValues
     res.render("my-account", { userData });
   })
+};
 
+module.exports.populateEditForm = (req, res) => {
+  const userId = req.app.get("user").id;
+  const { User } = req.app.get("models");
+  User.find({where: { id: userId } })
+    .then(foundUser => {
+      console.log("foundUser",foundUser.dataValues)
+      // res.json(foundUser)
+      res.render("edit-account-info", foundUser.dataValues)
+    });
 };
 
 module.exports.editAccount = (req, res, next) => {

--- a/routes/accountRoute.js
+++ b/routes/accountRoute.js
@@ -3,9 +3,12 @@
 const { Router } = require("express");
 const router = Router();
 
-const { myAccountView, editAccount } = require('../controllers/account-viewCtrl');
+const { myAccountView, editAccount, populateEditForm } = require('../controllers/account-viewCtrl');
 
 router.get('/account', myAccountView);
+
+router.get('/edit-account-info', populateEditForm);
+
 
 router.get('/edit-account-info', (req, res) => {
   res.render('edit-account-info');

--- a/views/edit-account-info.pug
+++ b/views/edit-account-info.pug
@@ -3,13 +3,13 @@ block content
   h2 Billing Information
   form.editAccount(name="editAccount" method="POST" action="/edit")
     h3 Street:
-    input(type="text" name="street" placeholder="street")
+    input(type="text" name="street" placeholder="street" value=`${street}`)
     h3 City:
-    input(type="text" name="city" placeholder="city")
+    input(type="text" name="city" placeholder="city" value=`${city}`)
     h3 State:
-    input(type="text" name="state" placeholder="state")
+    input(type="text" name="state" placeholder="state" value=`${state}`)
     h3 Zip:
-    input(type="text" name="zip" placeholder="zip")
+    input(type="text" name="zip" placeholder="zip" value=`${zip}`)
     h3 Phone:
-    input(type="text" name="phone" placeholder="phone")
+    input(type="text" name="phone" placeholder="phone" value=`${phone}`)
     button.edit-submit(type="submit") Update Info


### PR DESCRIPTION
## DESCRIPTION
The view for editing a user's account to pre-populates the form with the user's data.
Added because it is a requirement.

## STEPS TO TEST
1. npm start
2. log in
3. click my account
4. click edit account, if the user has data it should populate in the form.

## REFERENCE
#9 